### PR TITLE
Embed configs and rework CLI usage

### DIFF
--- a/src/game_config.rs
+++ b/src/game_config.rs
@@ -165,10 +165,10 @@ pub struct ScriptConfig {
 
 impl ScriptConfig {
     #[inline]
-    pub fn new<T: Read>(db_config: T) -> Result<Self, BBScriptError> {
+    pub fn new<T: Read>(config: T) -> Result<Self, BBScriptError> {
         use std::collections::HashSet;
         let config: Self =
-            de::from_reader(db_config).map_err(|e| BBScriptError::ConfigInvalid(e.to_string()))?;
+            de::from_reader(config).map_err(|e| BBScriptError::ConfigInvalid(e.to_string()))?;
 
         // initial sanity checks for the config
 


### PR DESCRIPTION
The configs are now embedded in the executable at build time which removes the need for users to have a proper folder structure and allows the program to list valid game IDs in the help menu. This now requires using the `-g` flag with a valid game ID, but also adds a `-c` flag which allows passing an external config file to use for parsing