### PR TITLE
fix missing endMove in dzy.bbscript in ggrev2

### DIFF
--- a/src/game_config.rs
+++ b/src/game_config.rs
@@ -660,6 +660,7 @@ pub enum CodeBlock {
     BeginJumpEntry,
     End,
     NoBlock,
+    BeginNonrecursive,
 }
 
 impl Default for CodeBlock {


### PR DESCRIPTION
In Guilty Gear Xrd Rev 2, the dzy.bbscript in move "GammaRay" is missing an endMoveRegister instruction which causes all indentation to remain incremented by 1 for all instructions that follow after it. This commit fixes that.

It also changes indentation of closing instructions, such as endSubroutine, so that they're shown with indent - 1 from what is the current behavior of the bbscript parser.