### PR TITLE
Make `arg` compound atomic in BBScript pest grammar

### DIFF
--- a/src/readable_bbscript.pest
+++ b/src/readable_bbscript.pest
@@ -12,7 +12,7 @@ function_name = @{
 
 args = { arg ~ ("," ~ arg)* ~ ","? }
 
-arg = {
+arg = ${
   "s16'" ~ string16 ~ "'"
 | "s32'" ~ string32 ~ "'"
 | "Mem(" ~ (named_var | var_id) ~ ")"


### PR DESCRIPTION
Fix #46 by making `arg` compound atomic, which prevents the implicit insertion of `WHITESPACE` and `COMMENT` rules